### PR TITLE
Serach History and Clear History Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,14 +178,21 @@
             <div id="park-info">
               <p strong>Come visit America's national parks for stunning natural landscapes, outdoor adventures, and unique experiences. Explore majestic peaks, colorful valleys, and witness wildlife in their natural habitat. Whether you're an outdoor enthusiast or looking for a peaceful retreat, the national parks offer something for everyone. Don't miss out on this opportunity to experience the wonders of nature.</p>
             </div> 
-      
+           
+
             <div id="local-storage-container" class="list">
                 
                 <div id="input-box" style="padding-bottom: 290px; background-color: white; border-radius: 0.8dvb"; class="info">                   
                 <!-- <div id="input-box">
                   <input type="text" name="" id="">                    
-                  <ul id="saved-parks"></ul>
+                  <ul id="saved-parks">
+                    
+                  </ul>
                 </div> -->
+
+                <div id="search-history-container" class="row m-0 search-history-container">
+                </div>
+                
                 </div>
               
             </div> 


### PR DESCRIPTION
### What is this change?
Displaying previously selected park name in search history list and store this data in local storage and when user click on clear history button previously selected park names delete from both history list and local storage.

### Why is this required?
This is required because when user wants to see previously search result of park names then simply user click on serach history and see again same previously search data.

### How did you test this?
when you select any park name then its display in search history list and when you select any park name then that park information is display again.